### PR TITLE
get the list of projects via IP name

### DIFF
--- a/efabless_tool.py
+++ b/efabless_tool.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from ast import arg
 import os, shutil, pickle, time, sys, logging, argparse, re
 
 # pipe handling
@@ -185,12 +184,15 @@ def list_projects(projects, fields):
 def list_by_ip(projects,ip):
     ip=re.sub("-","",ip)
     for project in projects:
+        log = ''
         if re.search(ip,project["summary"],re.IGNORECASE):
-            if project["giturl"] != "n/a":
-                logging.info("%-5s %-35s %-80s" % (project["id"], project["owner"], project["giturl"]))
-            else:
-                logging.info("%-5s %-35s [github link not found] https://platform.efabless.com/projects/%s" % (project["id"], project["owner"],project["id"]))
-
+            for field in ["id","owner","giturl"]:
+                log += format_map[field].format(project[field])
+                if re.search("n/a",log):
+                    log=re.sub("n/a","[github link not found] https://platform.efabless.com/projects/{0}".format(project["id"]),log)
+                log += " "
+            logging.info(log)
+                            
 
 def get_pins_in_lef(projects):
     from get_pins import get_pins

--- a/efabless_tool.py
+++ b/efabless_tool.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from ast import arg
 import os, shutil, pickle, time, sys, logging, argparse, re
 
 # pipe handling
@@ -181,6 +182,16 @@ def list_projects(projects, fields):
         logging.info(log)
 
 
+def list_by_ip(projects,ip):
+    ip=re.sub("-","",ip)
+    for project in projects:
+        if re.search(ip,project["summary"],re.IGNORECASE):
+            if project["giturl"] != "n/a":
+                logging.info("%-5s %-35s %-80s" % (project["id"], project["owner"], project["giturl"]))
+            else:
+                logging.info("%-5s %-35s [github link not found] https://platform.efabless.com/projects/%s" % (project["id"], project["owner"],project["id"]))
+
+
 def get_pins_in_lef(projects):
     from get_pins import get_pins
     max_pins = 0
@@ -205,7 +216,7 @@ if __name__ == '__main__':
     parser.add_argument('--update-cache', help='fetch the project data', action='store_const', const=True)
     parser.add_argument('--limit-update', help='just fetch the given number of projects', type=int, default=0)
     parser.add_argument('--debug', help="debug logging", action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.INFO)
-
+    parser.add_argument('--ip',help="get the list of all projects that has relation with the IP", type=str)
     args = parser.parse_args()
 
     # change directory to the script's path
@@ -231,6 +242,7 @@ if __name__ == '__main__':
         logging.error("project cache %s not found, use --update-cache to build it" % projects_db)
 
     # sort the projects by ID
+
     projects.sort(key=lambda x: int(x['id']))
 
     # handle ID selection by stdin
@@ -260,6 +272,9 @@ if __name__ == '__main__':
 
     elif args.get_pins:
         get_pins_in_lef(projects)
+    
+    elif args.ip:
+        list_by_ip(projects,args.ip)
 
     elif args.update_cache:
         from bs4 import BeautifulSoup


### PR DESCRIPTION
`./efabless_tool.py --ip op-amp` will list all the projects that has some relation with the op-amp.

The name ignores the character "-", so both "op-amp" and "opamp" are considered while listing down the projects.

If the github url is not found, the efabless project link will be printed out.

Ex:

```
59    Duy-Hieu Bui                        https://github.com/duyhieubui/caravel_vco_adc.git                               
277   Runkun Li                           [github link not found] https://platform.efabless.com/projects/277
```
